### PR TITLE
Fix character sale price input validation (#11)

### DIFF
--- a/apps/frontend/src/pages/CreateCharacterPage.tsx
+++ b/apps/frontend/src/pages/CreateCharacterPage.tsx
@@ -524,9 +524,23 @@ export const CreateCharacterPage: React.FC = () => {
                   type="number"
                   step="0.01"
                   min="0"
+                  pattern="^[0-9]*\.?[0-9]*$"
                   {...register('price')}
                   aria-invalid={!!errors.price}
                   placeholder="0.00"
+                  onInput={(e) => {
+                    const target = e.target as HTMLInputElement;
+                    const value = target.value;
+                    // Remove any invalid characters, keeping only digits and decimal point
+                    const cleaned = value.replace(/[^0-9.]/g, '');
+                    // Ensure only one decimal point
+                    const parts = cleaned.split('.');
+                    if (parts.length > 2) {
+                      target.value = parts[0] + '.' + parts.slice(1).join('');
+                    } else {
+                      target.value = cleaned;
+                    }
+                  }}
                 />
                 {errors.price && <ErrorMessage>{errors.price.message}</ErrorMessage>}
               </FormGroup>

--- a/apps/frontend/src/pages/EditCharacterPage.tsx
+++ b/apps/frontend/src/pages/EditCharacterPage.tsx
@@ -510,7 +510,21 @@ export const EditCharacterPage: React.FC = () => {
                 type="number"
                 step="0.01"
                 min="0"
+                pattern="^[0-9]*\.?[0-9]*$"
                 hasError={!!errors.price}
+                onInput={(e) => {
+                  const target = e.target as HTMLInputElement;
+                  const value = target.value;
+                  // Remove any invalid characters, keeping only digits and decimal point
+                  const cleaned = value.replace(/[^0-9.]/g, '');
+                  // Ensure only one decimal point
+                  const parts = cleaned.split('.');
+                  if (parts.length > 2) {
+                    target.value = parts[0] + '.' + parts.slice(1).join('');
+                  } else {
+                    target.value = cleaned;
+                  }
+                }}
               />
               {errors.price && <ErrorMessage>{errors.price.message}</ErrorMessage>}
             </FormGroup>


### PR DESCRIPTION
## Summary
• Fixed issue where users could type the letter 'e' in character sale price input fields
• Added real-time input validation to prevent invalid characters
• Maintained existing form validation and user experience

## Changes Made
• Added `pattern` attribute to restrict input to valid decimal format
• Implemented `onInput` handler to filter invalid characters in real-time
• Applied fix to both CreateCharacterPage and EditCharacterPage
• Preserved `type="number"` for mobile keyboard benefits

## Test Plan
- [ ] Verify typing 'e' alone is prevented in price fields
- [ ] Confirm valid decimal numbers work (15.99, 0.50, 100)
- [ ] Test form submission works with valid prices
- [ ] Check mobile keyboard displays numeric keypad
- [ ] Verify existing validation error messages still show

Fixes #11 