### PR TITLE
[GH-8] Fix private character access for owners

### DIFF
--- a/apps/backend/src/characters/characters.resolver.ts
+++ b/apps/backend/src/characters/characters.resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver, Query, Mutation, Args, ID, Context, ResolveField, Parent, Int } from '@nestjs/graphql';
 import { UseGuards, ForbiddenException } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { CharactersService } from './characters.service';
 import { Character as CharacterEntity, CharacterConnection } from './entities/character.entity';
@@ -33,6 +34,7 @@ export class CharactersResolver {
   }
 
   @Query(() => CharacterConnection)
+  @UseGuards(OptionalJwtAuthGuard)
   async characters(
     @Args('filters', { nullable: true }) filters?: CharacterFiltersInput,
     @CurrentUser() user?: any,
@@ -41,6 +43,7 @@ export class CharactersResolver {
   }
 
   @Query(() => CharacterEntity)
+  @UseGuards(OptionalJwtAuthGuard)
   async character(
     @Args('id', { type: () => ID }) id: string,
     @CurrentUser() user?: any,
@@ -120,6 +123,7 @@ export class CharactersResolver {
 
   // Query for characters by specific user
   @Query(() => CharacterConnection)
+  @UseGuards(OptionalJwtAuthGuard)
   async userCharacters(
     @Args('userId', { type: () => ID }) userId: string,
     @Args('filters', { nullable: true }) filters?: CharacterFiltersInput,


### PR DESCRIPTION
## Summary
Fixes the issue where character owners couldn't view their own private characters, getting a "Character not found" error instead.

## Root Cause
The character GraphQL queries (`character`, `characters`, `userCharacters`) were missing the `@UseGuards(OptionalJwtAuthGuard)` decorator. This caused the `@CurrentUser()` decorator to return `undefined`, making the permission check fail even for character owners.

## Changes
- Added `OptionalJwtAuthGuard` import to `characters.resolver.ts`
- Added `@UseGuards(OptionalJwtAuthGuard)` to three character queries:
  - `character()` - single character lookup
  - `characters()` - character list with filters  
  - `userCharacters()` - characters by specific user

## Test Plan
- [x] Private characters: Owners can view their own private characters without errors
- [x] Public characters: Work for both authenticated and unauthenticated users
- [x] Security: Unauthenticated users still cannot access private characters
- [x] No regressions: All existing functionality continues to work

## Screenshots
Tested with both authenticated and unauthenticated users:
- ✅ Authenticated user can view their own private characters
- ✅ Public characters accessible to all users
- ✅ Private characters properly blocked for non-owners

Closes #8