### PR TITLE
Fix Apollo cache invalidation for create mutations

### DIFF
--- a/apps/frontend/src/pages/CreateCharacterPage.tsx
+++ b/apps/frontend/src/pages/CreateCharacterPage.tsx
@@ -7,7 +7,7 @@ import { useMutation } from '@apollo/client';
 import { toast } from 'react-hot-toast';
 import styled from 'styled-components';
 import { Button } from '@chardb/ui';
-import { CREATE_CHARACTER, GET_CHARACTERS } from '../graphql/characters';
+import { CREATE_CHARACTER, GET_CHARACTERS, GET_MY_CHARACTERS } from '../graphql/characters';
 
 const characterSchema = z.object({
   name: z.string()
@@ -314,7 +314,10 @@ export const CreateCharacterPage: React.FC = () => {
   });
 
   const [createCharacter] = useMutation(CREATE_CHARACTER, {
-    refetchQueries: [{ query: GET_CHARACTERS }],
+    refetchQueries: [
+      { query: GET_CHARACTERS },
+      { query: GET_MY_CHARACTERS },
+    ],
   });
 
   const isSellable = watch('isSellable');

--- a/apps/frontend/src/pages/CreateGalleryPage.tsx
+++ b/apps/frontend/src/pages/CreateGalleryPage.tsx
@@ -7,7 +7,7 @@ import { useMutation, useQuery } from '@apollo/client';
 import { toast } from 'react-hot-toast';
 import styled from 'styled-components';
 import { Button } from '@chardb/ui';
-import { CREATE_GALLERY, GET_GALLERIES } from '../graphql/galleries';
+import { CREATE_GALLERY, GET_GALLERIES, GET_MY_GALLERIES } from '../graphql/galleries';
 import { GET_MY_CHARACTERS, Character } from '../graphql/characters';
 
 const gallerySchema = z.object({
@@ -268,7 +268,10 @@ export const CreateGalleryPage: React.FC = () => {
   });
 
   const [createGallery] = useMutation(CREATE_GALLERY, {
-    refetchQueries: [{ query: GET_GALLERIES }],
+    refetchQueries: [
+      { query: GET_GALLERIES },
+      { query: GET_MY_GALLERIES },
+    ],
   });
 
   // Fetch user's characters for the character association dropdown

--- a/apps/frontend/src/pages/CreateTextPage.tsx
+++ b/apps/frontend/src/pages/CreateTextPage.tsx
@@ -7,7 +7,7 @@ import { useMutation } from "@apollo/client";
 import { toast } from "react-hot-toast";
 import styled from "styled-components";
 import { Button } from "@chardb/ui";
-import { CREATE_TEXT_MEDIA, GET_CHARACTER_MEDIA } from "../graphql/media";
+import { CREATE_TEXT_MEDIA, GET_CHARACTER_MEDIA, GET_MY_MEDIA, GET_MEDIA } from "../graphql/media";
 import { useGetCharacterQuery } from "../graphql/characters";
 import { useGetMyGalleriesQuery } from "../graphql/galleries";
 import { TextFormatting, Visibility } from "../generated/graphql";
@@ -325,14 +325,18 @@ export const CreateTextPage: React.FC = () => {
   const galleries = galleriesData?.myGalleries?.galleries || [];
 
   const [createTextMedia] = useMutation(CREATE_TEXT_MEDIA, {
-    refetchQueries: characterId
-      ? [
-          {
-            query: GET_CHARACTER_MEDIA,
-            variables: { characterId, filters: { limit: 8 } },
-          },
-        ]
-      : [],
+    refetchQueries: [
+      { query: GET_MY_MEDIA },
+      { query: GET_MEDIA },
+      ...(characterId
+        ? [
+            {
+              query: GET_CHARACTER_MEDIA,
+              variables: { characterId, filters: { limit: 8 } },
+            },
+          ]
+        : []),
+    ],
   });
 
   const handleBackClick = () => {


### PR DESCRIPTION
## Summary
- Fixes #7 - Resolves issue where newly created characters and galleries don't appear in dropdown lists until page refresh
- Improves Apollo cache invalidation for create mutations across the app

## Changes Made
- **CREATE_CHARACTER**: Added `GET_MY_CHARACTERS` to refetch queries
- **CREATE_GALLERY**: Added `GET_MY_GALLERIES` to refetch queries  
- **CREATE_TEXT_MEDIA**: Added `GET_MY_MEDIA` and `GET_MEDIA` to refetch queries

## Problem
When users created characters or galleries, they wouldn't appear in dropdown selectors (like when uploading images) until the page was manually refreshed. This was due to incomplete Apollo cache invalidation - the mutations were only refetching public queries (`GET_CHARACTERS`, `GET_GALLERIES`) but not the user-specific queries (`GET_MY_CHARACTERS`, `GET_MY_GALLERIES`) that populate the dropdown lists.

## Solution
Added comprehensive refetch queries to ensure both public and user-specific data is refreshed when new content is created. This guarantees that:

1. ✅ New characters appear immediately in character selection dropdowns
2. ✅ New galleries appear immediately in gallery selection dropdowns  
3. ✅ New media appears immediately in media lists
4. ✅ No manual page refresh required

## Test plan
- [x] Verify TypeScript compilation passes
- [ ] Create a new character and immediately navigate to image upload - verify character appears in dropdown
- [ ] Create a new gallery and verify it appears in relevant selection lists
- [ ] Create text content and verify media lists are updated

Closes #7