### PR TITLE
[GH-69] Fix role list cache invalidation

### DIFF
--- a/apps/frontend/src/components/admin/RoleEditor.tsx
+++ b/apps/frontend/src/components/admin/RoleEditor.tsx
@@ -26,6 +26,7 @@ import {
   useUpdateRoleMutation,
   CreateRoleInput,
   UpdateRoleInput,
+  RolesByCommunityDetailedDocument,
 } from "../../generated/graphql";
 
 /**
@@ -452,6 +453,12 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
             id: editingRole.id,
             input: updateInput,
           },
+          refetchQueries: [
+            {
+              query: RolesByCommunityDetailedDocument,
+              variables: { communityId, first: 50, after: null },
+            },
+          ],
         });
       } else {
         const createInput: CreateRoleInput = {
@@ -464,6 +471,12 @@ export const RoleEditor: React.FC<RoleEditorProps> = ({
           variables: {
             input: createInput,
           },
+          refetchQueries: [
+            {
+              query: RolesByCommunityDetailedDocument,
+              variables: { communityId, first: 50, after: null },
+            },
+          ],
         });
       }
 


### PR DESCRIPTION
## Summary
Fixed issue where newly created or edited roles didn't appear in the role list without a manual page refresh. Added Apollo Client cache invalidation to automatically refetch the roles query after mutations.

## Changes
- Added `RolesByCommunityDetailedDocument` import to `RoleEditor.tsx`
- Added `refetchQueries` to `createRole` mutation to invalidate cache after role creation
- Added `refetchQueries` to `updateRole` mutation to invalidate cache after role editing

## Testing
Verified with automated Playwright tests:
- ✅ Creating a new role updates the list immediately (role count: 2→3)
- ✅ Editing an existing role updates permissions immediately (permissions: 6→7)
- ✅ No page refresh required for either operation

## Related Issue
Fixes #69

## Test Plan
- [x] Create a new role in community settings
- [x] Verify role appears immediately in the role list
- [x] Edit an existing role's permissions
- [x] Verify changes appear immediately in the role card
- [x] Confirm no manual page refresh is needed