### PR TITLE
Fix ambiguous 'Create' text in header navigation

### DIFF
--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -93,7 +93,7 @@ export const Header: React.FC = () => {
 
           {user ? (
             <UserMenu>
-              <NavLink to="/character/create">Create</NavLink>
+              <NavLink to="/character/create">Create Character</NavLink>
               <NavLink to="/upload">Upload</NavLink>
               <UserInfo to={`/user/${user.username}`}>
                 {user.avatarUrl && <Avatar src={user.avatarUrl} alt={user.username} />}


### PR DESCRIPTION
## Summary
- Updated the header navigation link text from "Create" to "Create Character" for improved clarity

## Changes
- Modified `apps/frontend/src/components/Header.tsx` to change the navigation link text from the ambiguous "Create" to the more descriptive "Create Character"

## Context
Users may be confused about what the "Create" button/link does, especially in contexts where multiple things could be created (characters, species, communities, etc.). This change makes it immediately clear that the link creates a character.

## Test plan
- [ ] Verify the header navigation displays "Create Character" instead of "Create"
- [ ] Ensure the link still navigates to `/character/create`
- [ ] Confirm type checking passes (already verified)
- [ ] Visual test in browser to ensure text displays correctly

Fixes #99