### PR TITLE
Release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.0.1] - 2025-11-02
+
+### Fixed
+
+- **Discord Guild Validation (#133)**: Fixed backend `validateDiscordGuild` query configuration issue
+
 ## [v5.0.0] - 2025-11-02
 
 ## [v4.2.0] - 2025-10-28

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.0.1] - 2025-11-02
+
 ### Fixed
 
 - **Discord Guild Validation (#133)**: Fixed `validateDiscordGuild` query missing `communityId` parameter that `@ResolveCommunityFrom` decorator was expecting, preventing proper permission validation

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Release v5.0.1

This patch release fixes a critical issue with Discord guild validation.

### Changes

#### Backend
- **Discord Guild Validation (#133)**: Fixed `validateDiscordGuild` query missing `communityId` parameter that `@ResolveCommunityFrom` decorator was expecting, preventing proper permission validation

### Version Updates
- All packages bumped from 5.0.0 to 5.0.1

---

**Next Steps:**
Once this PR is approved and merged, tag the release on main with:
```bash
git tag v5.0.1
git push --tags
```