### PR TITLE
fix: allow unauthenticated users to view public media

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unauthenticated Media Access**: Fixed `userHasLiked` field blocking unauthenticated users from viewing public media
 - **Character Creation Ownership**: Fixed `assignToSelf` parameter not being respected
   - Characters now properly created without owner when `assignToSelf: false`
   - Works in conjunction with `canCreateOrphanedCharacter` permission

--- a/apps/backend/src/auth/constants/sentinel-values.ts
+++ b/apps/backend/src/auth/constants/sentinel-values.ts
@@ -16,3 +16,5 @@ export const TRUTHY_NULL = Symbol("TRUTHY_NULL");
  * Will be transformed to actual empty string by SentinelValueInterceptor.
  */
 export const TRUTHY_EMPTY_STRING = Symbol("TRUTHY_EMPTY_STRING");
+
+export const TRUTHY_FALSE = Symbol("TRUTHY_FALSE");

--- a/apps/backend/src/auth/filters/FalseOnForbiddenFilter.ts
+++ b/apps/backend/src/auth/filters/FalseOnForbiddenFilter.ts
@@ -1,0 +1,31 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  ForbiddenException,
+} from "@nestjs/common";
+import { GqlContextType } from "@nestjs/graphql";
+import { TRUTHY_FALSE } from "../constants/sentinel-values";
+
+/**
+ * Exception filter that catches ForbiddenException in GraphQL field resolvers
+ * and returns false instead of throwing an error.
+ *
+ * Returns TRUTHY_FALSE sentinel which will be transformed back to actual false
+ * by sentinelValueMiddleware.
+ *
+ * Apply with:
+ * @UseFilters(NullOnForbiddenFilter)
+ * @ResolveField("fieldName", () => Type, { nullable: true, middleware: [sentinelValueMiddleware] })
+ */
+@Catch(ForbiddenException)
+export class FalseOnForbiddenFilter implements ExceptionFilter {
+  catch(exception: ForbiddenException, host: ArgumentsHost) {
+    // Only handle GraphQL contexts
+    if (host.getType<GqlContextType>() !== "graphql") {
+      throw exception;
+    }
+
+    return TRUTHY_FALSE;
+  }
+}

--- a/apps/backend/src/auth/middleware/sentinel-value.middleware.ts
+++ b/apps/backend/src/auth/middleware/sentinel-value.middleware.ts
@@ -1,5 +1,9 @@
 import { FieldMiddleware, MiddlewareContext, NextFn } from "@nestjs/graphql";
-import { TRUTHY_NULL, TRUTHY_EMPTY_STRING } from "../constants/sentinel-values";
+import {
+  TRUTHY_NULL,
+  TRUTHY_EMPTY_STRING,
+  TRUTHY_FALSE,
+} from "../constants/sentinel-values";
 
 /**
  * GraphQL field middleware that transforms sentinel values to their actual values.
@@ -23,6 +27,9 @@ export const sentinelValueMiddleware: FieldMiddleware = async (
   }
   if (value === TRUTHY_EMPTY_STRING) {
     return "";
+  }
+  if (value === TRUTHY_FALSE) {
+    return false;
   }
 
   return value;

--- a/apps/backend/src/media/media.resolver.ts
+++ b/apps/backend/src/media/media.resolver.ts
@@ -17,7 +17,7 @@ import {
   AuthenticatedCurrentUserType,
   CurrentUserType,
 } from "../auth/types/current-user.type";
-import { ForbiddenException } from "@nestjs/common";
+import { ForbiddenException, UseFilters } from "@nestjs/common";
 import { MediaService } from "./media.service";
 import { UsersService } from "../users/users.service";
 import { CharactersService } from "../characters/characters.service";
@@ -49,6 +49,8 @@ import {
   mapPrismaMediaConnectionToGraphQL,
 } from "./utils/media-resolver-mappers";
 import { mapPrismaGalleryToGraphQL } from "../galleries/utils/gallery-resolver-mappers";
+import { FalseOnForbiddenFilter } from "../auth/filters/FalseOnForbiddenFilter";
+import { sentinelValueMiddleware } from "../auth/middleware/sentinel-value.middleware";
 
 /**
  * GraphQL resolver for media operations
@@ -428,8 +430,10 @@ export class MediaResolver {
    * Resolves whether the current user has liked this media
    */
   @AllowAnyAuthenticated()
+  @UseFilters(FalseOnForbiddenFilter)
   @ResolveField(() => Boolean, {
     description: "Whether the current user has liked this media",
+    middleware: [sentinelValueMiddleware],
   })
   async userHasLiked(
     @Parent() media: MediaEntity,


### PR DESCRIPTION
## Summary

Fixes unauthenticated users being blocked from viewing public media due to `userHasLiked` field throwing `ForbiddenException`.

Resolves production errors:
```
Path: characterMedia -> media -> 0 -> userHasLiked
ForbiddenException: Forbidden resource
```

## Changes

- Applied `@UseFilters(FalseOnForbiddenFilter)` to `userHasLiked` field resolver in `media.resolver.ts`
- Added `sentinelValueMiddleware` to field options
- Created `FalseOnForbiddenFilter` to catch `ForbiddenException` and return `TRUTHY_FALSE` sentinel
- Middleware transforms sentinel back to actual `false` value

## How It Works

1. Unauthenticated user queries public media
2. `userHasLiked` field requires authentication (`@AllowAnyAuthenticated()`)
3. Guard throws `ForbiddenException`
4. `FalseOnForbiddenFilter` catches exception and returns `TRUTHY_FALSE` sentinel
5. `sentinelValueMiddleware` transforms sentinel → `false`
6. GraphQL returns `false` to client instead of error

## Test Plan

- [ ] Navigate to public media as unauthenticated user
- [ ] Verify media loads without errors
- [ ] Verify `userHasLiked` returns `false`
- [ ] Login and verify `userHasLiked` still works for authenticated users