### PR TITLE
fix(frontend): enable browser shortcuts for card navigation (#154)

### DIFF
--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Card Navigation Browser Shortcuts (#154)**: Fixed card components to support browser shortcuts (ctrl+click, middle-click, right-click "Open in new tab")
+  - Converted CharacterCard, MediaCard, and GalleryCard from `<div onClick>` to semantic `<Link>` elements
+  - Enables proper browser navigation shortcuts on all clickable cards
+  - Improves accessibility and user experience
 - **Markdown Line Breaks (#149)**: Replaced manual markdown parsing with `react-markdown`
   - This will significantly enhance the markdown features available, and enables preserving linebreaks.
 - **Character Creation Ownership Bug**: Fixed "Leave Unassigned" option not working when creating characters

--- a/apps/frontend/src/components/CharacterCard.tsx
+++ b/apps/frontend/src/components/CharacterCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { Character } from '../generated/graphql';
 import { Tag } from './Tag';
@@ -17,7 +17,9 @@ export type CharacterCardItem = Pick<Character,
   _count?: Pick<NonNullable<Character['_count']>, 'media'> | null;
 };
 
-const Card = styled.div`
+const Card = styled(Link)`
+  display: block;
+  text-decoration: none;
   background: ${({ theme }) => theme.colors.background};
   border-radius: 12px;
   box-shadow: ${({ theme }) => theme.shadows.sm};
@@ -26,12 +28,12 @@ const Card = styled.div`
   cursor: pointer;
   overflow: hidden;
   position: relative;
-  
+
   &:hover {
     transform: translateY(-2px);
     box-shadow: ${({ theme }) => theme.shadows.lg};
   }
-  
+
   &:focus {
     outline: 2px solid ${({ theme }) => theme.colors.primary};
     outline-offset: 2px;
@@ -171,29 +173,9 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
   showOwner = true,
   showEditButton = false
 }) => {
-  const navigate = useNavigate();
-
-  const handleClick = () => {
-    navigate(`/character/${character.id}`);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleClick();
-    }
-  };
-
-  const handleButtonClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent card click when button is clicked
-  };
-
   return (
     <Card
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-      role="button"
+      to={`/character/${character.id}`}
       aria-label={`View character ${character.name}`}
     >
       <ButtonGroup>
@@ -201,7 +183,6 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
         {showEditButton && (
           <EditButton
             to={`/character/${character.id}/edit`}
-            onClick={handleButtonClick}
           >
             Edit
           </EditButton>

--- a/apps/frontend/src/components/CopyIdButton.tsx
+++ b/apps/frontend/src/components/CopyIdButton.tsx
@@ -50,6 +50,7 @@ export const CopyIdButton: React.FC<CopyIdButtonProps> = ({
   }
 
   const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
     e.stopPropagation();
     navigator.clipboard.writeText(id);
     toast.success('ID copied to clipboard');

--- a/apps/frontend/src/components/MediaCard.tsx
+++ b/apps/frontend/src/components/MediaCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { MediaGridItem } from './MediaGrid';
 
-const Card = styled.div`
+const Card = styled(Link)`
+  display: block;
+  text-decoration: none;
   background: ${({ theme }) => theme.colors.background};
   border-radius: 12px;
   box-shadow: ${({ theme }) => theme.shadows.sm};
@@ -12,12 +14,12 @@ const Card = styled.div`
   cursor: pointer;
   overflow: hidden;
   position: relative;
-  
+
   &:hover {
     transform: translateY(-2px);
     box-shadow: ${({ theme }) => theme.shadows.lg};
   }
-  
+
   &:focus {
     outline: 2px solid ${({ theme }) => theme.colors.primary};
     outline-offset: 2px;
@@ -234,8 +236,8 @@ interface MediaCardProps {
  * A card component that displays either image or text media with metadata
  * Automatically adapts its layout based on the media type
  */
-export const MediaCard: React.FC<MediaCardProps> = ({ 
-  media, 
+export const MediaCard: React.FC<MediaCardProps> = ({
+  media,
   showOwner = true,
   characterId,
   currentMainMediaId,
@@ -243,7 +245,6 @@ export const MediaCard: React.FC<MediaCardProps> = ({
   onRemoveAsMain,
   isSettingMain = false
 }) => {
-  const navigate = useNavigate();
   const isImage = !!media.image;
   const isText = !!media.textContent;
   const isMainMedia = currentMainMediaId === media.id;
@@ -276,26 +277,15 @@ export const MediaCard: React.FC<MediaCardProps> = ({
     }
   };
 
-  const handleClick = () => {
-    navigate(`/media/${media.id}`);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleClick();
-    }
-  };
-
   const handleSetAsMain = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent card click
+    e.preventDefault(); // Prevent card navigation
     if (onSetAsMain && !isSettingMain) {
       onSetAsMain(media.id);
     }
   };
 
   const handleRemoveAsMain = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent card click
+    e.preventDefault(); // Prevent card navigation
     if (onRemoveAsMain && !isSettingMain) {
       onRemoveAsMain();
     }
@@ -303,10 +293,7 @@ export const MediaCard: React.FC<MediaCardProps> = ({
 
   return (
     <Card
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-      role="button"
+      to={`/media/${media.id}`}
       aria-label={`View ${isImage ? 'image' : 'text'} ${media.title}`}
     >
       <MediaSection>

--- a/apps/frontend/src/pages/GalleriesPage.tsx
+++ b/apps/frontend/src/pages/GalleriesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import styled from "styled-components";
 import { useGetGalleriesQuery, GalleryFiltersInput } from "../generated/graphql";
 import { LoadingSpinner } from "../components/LoadingSpinner";
@@ -148,7 +148,9 @@ const GalleryGrid = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.xl};
 `;
 
-const GalleryCard = styled.div`
+const GalleryCard = styled(Link)`
+  display: block;
+  text-decoration: none;
   background: ${({ theme }) => theme.colors.background};
   border-radius: 12px;
   padding: ${({ theme }) => theme.spacing.lg};
@@ -364,22 +366,6 @@ export const GalleriesPage: React.FC = () => {
     }
   }, [data, filters, fetchMore]);
 
-  const handleGalleryClick = useCallback(
-    (galleryId: string) => {
-      navigate(`/gallery/${galleryId}`);
-    },
-    [navigate],
-  );
-
-  const handleGalleryKeyDown = useCallback(
-    (e: React.KeyboardEvent, galleryId: string) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        handleGalleryClick(galleryId);
-      }
-    },
-    [handleGalleryClick],
-  );
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("en-US", {
@@ -463,10 +449,7 @@ export const GalleriesPage: React.FC = () => {
               {data?.galleries.galleries.map((gallery) => (
                 <GalleryCard
                   key={gallery.id}
-                  onClick={() => handleGalleryClick(gallery.id)}
-                  onKeyDown={(e) => handleGalleryKeyDown(e, gallery.id)}
-                  tabIndex={0}
-                  role="button"
+                  to={`/gallery/${gallery.id}`}
                   aria-label={`View gallery ${gallery.name}`}
                 >
                   <GalleryName>{gallery.name}</GalleryName>


### PR DESCRIPTION
## Summary
- Fixed card components to support browser shortcuts (ctrl+click, middle-click, right-click "Open in new tab")
- Converted CharacterCard, MediaCard, and GalleryCard from `<div onClick>` to semantic `<Link>` elements
- Fixed CopyIdButton to prevent navigation when clicked on cards

## Changes
- **CharacterCard**: Converted from `styled.div` with onClick to `styled(Link)` with proper `to` prop
- **MediaCard**: Same conversion, preserved action button functionality with preventDefault
- **GalleriesPage GalleryCard**: Same conversion pattern
- **CopyIdButton**: Added preventDefault to prevent link navigation when clicking the copy button
- Removed onClick, onKeyDown, tabIndex, and role="button" props that are no longer needed

## Test plan
- [x] Type checking passes
- [ ] Manually test ctrl+click on CharacterCard opens in new tab
- [ ] Manually test middle-click on MediaCard opens in new tab
- [ ] Manually test right-click → "Open in new tab" on GalleryCard works
- [ ] Manually test CopyIdButton doesn't navigate when clicked
- [ ] Manually test Edit button on CharacterCard still works correctly
- [ ] Manually test Set as Main buttons on MediaCard still work

Resolves #154