### PR TITLE
feat(items): add image upload for item types (#160)

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Item Type Image Upload (#160)**: Added support for uploading images directly to item types
+  - Added `itemTypeId` parameter to image upload endpoint
+  - Automatically associates uploaded images with item types via `ItemType.imageId`
+  - Permission checking via `CanManageItems` community permission
+  - Images stored in S3 with same variant generation as other media
 - **SQS Queue Consumer**: Implemented prize distribution system for Discord bot integration
   - Created queue consumer module that polls SQS for prize award events
   - Added item prize handler for granting existing item types to Discord users

--- a/apps/backend/src/images/images.controller.ts
+++ b/apps/backend/src/images/images.controller.ts
@@ -30,6 +30,7 @@ export class ImagesController {
     const uploadInput = {
       file,
       characterId: body.characterId,
+      itemTypeId: body.itemTypeId,
       galleryId: body.galleryId,
       description: body.description,
       altText: body.altText,

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Item Type Image Upload (#160)**: Added image upload functionality for item types
+  - Upload images directly in item type create/edit modals
+  - Single image support for item types
+  - Images displayed on item type cards & inventory
 - **Admin Copy ID Buttons**: Copy ID buttons on character cards and item type cards for admins
 - **Image Upload System**: Complete image upload functionality with S3 storage integration
   - Upload page with character and gallery association


### PR DESCRIPTION
## Summary
- Added image upload functionality for item types directly in create/edit modals
- Single image support with automatic association to ItemType
- Permission validation via CanManageItems
- Images displayed on item type cards and inventory

## Backend Changes
- Added `itemTypeId` parameter to image upload endpoint (`/images/upload`)
- Added `verifyItemTypeEditPermission()` method to validate CanManageItems permission
- Image upload transaction now updates ItemType.imageId when itemTypeId is provided
- Reuses existing S3 upload pipeline with original/medium/thumbnail variants

## Frontend Changes
- Added `ImageUpload` component to item type create/edit modals in `CommunityItemsAdminPage`
- Replaced "Icon URL" text input with visual image upload interface
- Single image constraint (maxFiles=1) with proper state management
- Upload flow: create/update item type → upload image → associate with item type
- Proper cleanup of image selection when modals open/close
- Toast notifications for upload success/failure

## Test Plan
- [ ] Create new item type with image upload
- [ ] Verify image appears on item type card
- [ ] Verify image appears in inventory
- [ ] Edit existing item type and upload new image
- [ ] Verify old image is replaced with new one
- [ ] Test permission validation (non-admins should not be able to upload)
- [ ] Verify all image variants (original, medium, thumbnail) are generated
- [ ] Test modal cleanup (image clears when reopening modal)

Resolves #160