### PR TITLE
Release v8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.1.1] - 2026-02-08
+
 ## [v8.1.0] - 2026-02-08
 
 ## [v8.0.0] - 2026-02-01

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.1.1] - 2026-02-08
+
 ## [v8.1.0] - 2026-02-08
 
 ### Added

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.1.1] - 2026-02-08
+
 ### Fixed
 
 - **Admin Navigation Visibility**: Gate each admin sidebar item by its specific permission instead of broad checks

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

- Patch release v8.1.1

### Frontend
- **Fix**: Gate admin navigation sidebar items by specific permissions instead of broad checks (moderation, items, dashboard links)

### Backend / Root
- No unreleased changes (version bump only)

## Checklist
- [ ] Review changelog entries
- [ ] Merge PR
- [ ] Tag release on main: `git tag v8.1.1 && git push --tags`