### PR TITLE
fix(backend): artist credit not persisting on image upload

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Artist credit not persisting on image upload**: Pass `artistId`, `artistName`, and `artistUrl` from the upload controller to the images service (#147)
+
 ## [v8.1.1] - 2026-02-08
 
 ## [v8.1.0] - 2026-02-08

--- a/apps/backend/src/images/images.controller.ts
+++ b/apps/backend/src/images/images.controller.ts
@@ -27,7 +27,7 @@ export class ImagesController {
       throw new BadRequestException("No file provided");
     }
 
-    const uploadInput = {
+    const uploadInput: Parameters<ImagesService["upload"]>[1] = {
       file,
       characterId: body.characterId,
       itemTypeId: body.itemTypeId,
@@ -37,6 +37,11 @@ export class ImagesController {
       isNsfw: body.isNsfw === "true",
       visibility: body.visibility,
       sensitiveContentDescription: body.sensitiveContentDescription,
+      artistId:
+        body.artistType === "onsite" ? body.artistLink : undefined,
+      artistName: body.artistLabel || undefined,
+      artistUrl:
+        body.artistType === "offsite" ? body.artistLink : undefined,
     };
 
     return this.imagesService.upload(req.user.id, uploadInput);


### PR DESCRIPTION
## Summary
- The upload controller was not forwarding `artistId`, `artistName`, or `artistUrl` to the images service, so artist credits were silently dropped during upload
- Maps frontend form fields (`artistType`, `artistLink`, `artistLabel`) to service input (`artistId`/`artistUrl`, `artistName`)
- Also typed the upload input with `Parameters<ImagesService["upload"]>[1]` to catch similar omissions at compile time

## Test plan
- [x] Upload an image with an off-site artist credit and verify it persists (confirmed via DB and media detail page)
- [ ] Upload an image with an on-site artist credit and verify `artistId` is set

Closes #147