### PR TITLE
Release v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.2.0] - 2026-02-09
+
 ## [v8.1.1] - 2026-02-08
 
 ## [v8.1.0] - 2026-02-08

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.2.0] - 2026-02-09
+
 ### Added
 
 - **Editable media title at upload**: Accept optional `title` field in upload endpoint; defaults to original filename

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v8.2.0] - 2026-02-09
+
 ### Added
 
 - **Title field on upload form**: Users can set a custom title when uploading images; defaults to original filename if left blank

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

Release v8.2.0 — minor release with the following changes:

### Backend
- **Editable media title at upload**: Accept optional `title` field in upload endpoint; defaults to original filename
- **Remove `filename` from GraphQL API**: `Image.filename` field no longer exposed
- **Activity feed uses media titles**: IMAGE_UPLOADED feed items now show media title instead of UUID filenames
- **Fix artist credit not persisting on image upload** (#147)

### Frontend
- **Title field on upload form**: Users can set a custom title when uploading images
- **Remove `filename` from GraphQL queries**: Updated to reflect API change
- **Upload success screen shows media title** instead of UUID filenames
- **Fix broken image preview on post-upload screen** (#166)

## Test plan
- [ ] Verify image upload with custom title works end-to-end
- [ ] Verify image upload without title defaults to filename
- [ ] Verify activity feed shows media titles correctly
- [ ] Verify artist credit fields persist on upload
- [ ] Verify post-upload image preview renders correctly