### PR TITLE
Release v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.1.0] - 2026-02-09
+
 ## [v9.0.0] - 2026-02-09
 
 ## [v8.2.0] - 2026-02-09

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.1.0] - 2026-02-09
+
 ### Added
 
 - **Description length validation**: Added `@MaxLength(3000)` validation to `description` field in `CreateTextMediaInput` and `UpdateMediaInput` DTOs

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.1.0] - 2026-02-09
+
 ### Added
 
 - **Markdown support for media descriptions**: Image captions and descriptions now support bold, italic, headings, links, lists, and other markdown formatting with a live preview toggle

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

- **Frontend**: Markdown support for media descriptions with live preview toggle, safe link handling (new tab), increased description limit to 3,000 characters
- **Backend**: Added `@MaxLength(3000)` validation for media description fields

## Changelog

See individual CHANGELOG.md files for full details.

## Post-merge steps

1. `git tag v9.1.0` on main
2. `git push --tags`