### PR TITLE
Fix case-sensitive email login

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Case-sensitive email login**: Normalize emails to lowercase in login, signup, password reset, and user creation flows. Includes database migration to lowercase existing emails.
+
 ## [v9.1.0] - 2026-02-09
 
 ### Added

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -108,6 +108,7 @@ export class AuthService {
   }
 
   async signup(input: SignupServiceInput): Promise<AuthResponse> {
+    const normalizedEmail = input.email.toLowerCase();
     return await this.prisma.$transaction(async (tx) => {
       // 1. Validate invite code first (using regular service, not transaction)
       const inviteCode = await this.inviteCodesService.findOne(input.inviteCode);
@@ -117,7 +118,7 @@ export class AuthService {
 
       // 2. Check for existing user by email (within transaction)
       const existingUserByEmail = await tx.user.findUnique({
-        where: { email: input.email }
+        where: { email: normalizedEmail }
       });
       if (existingUserByEmail) {
         throw new ConflictException('User with this email already exists');
@@ -136,7 +137,7 @@ export class AuthService {
       const user = await tx.user.create({
         data: {
           username: input.username,
-          email: input.email,
+          email: normalizedEmail,
           passwordHash: hashedPassword,
           displayName: input.displayName,
         },

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -64,7 +64,7 @@ export class UsersService {
     return this.db.user.create({
       data: {
         username: input.username,
-        email: input.email,
+        email: input.email.toLowerCase(),
         passwordHash: input.passwordHash,
         displayName: input.displayName,
       },
@@ -103,7 +103,7 @@ export class UsersService {
 
   async findByEmail(email: string) {
     return this.db.user.findUnique({
-      where: { email },
+      where: { email: email.toLowerCase() },
     });
   }
 

--- a/packages/database/prisma/migrations/20260209000000_normalize_emails_lowercase/migration.sql
+++ b/packages/database/prisma/migrations/20260209000000_normalize_emails_lowercase/migration.sql
@@ -1,0 +1,3 @@
+-- Normalize existing emails to lowercase.
+-- This will fail if duplicate case-variant emails exist (requires manual resolution).
+UPDATE users SET email = LOWER(email);


### PR DESCRIPTION
## Summary
- Normalize emails to lowercase in `findByEmail()` and `create()` in `UsersService`
- Normalize email at top of `signup()` in `AuthService` (uses Prisma tx client directly)
- Add database migration to lowercase all existing emails

Closes #175

## Flows Covered
| Flow | How it's covered |
|------|-----------------|
| Login | `validateUser()` → `findByEmail()` (normalized) |
| Signup | `signup()` normalizes email directly |
| Forgot Password | `requestPasswordReset()` → `findByEmail()` (normalized) |
| Existing data | Database migration lowercases all emails |

## Test plan
- [x] Login with correct-case email (baseline)
- [x] Login with all-uppercase email (`MEMBER@TEST.LOCAL`)
- [x] Login with mixed-case email against lowercase DB entry
- [x] Register with mixed-case email (`CaseTestUser@Test.local`), verify DB stores lowercase
- [x] Login with original mixed-case email after registration
- [x] Forgot password with uppercase email (user found, email send failed due to pre-existing template bug)
- [x] `yarn type-check` passes