### PR TITLE
fix(auth): allow unauthenticated access to species pages

### DIFF
--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Species page**: Species pages now load for users who are not logged in (#174)
+- **Community colors**: Fixed community color's community field not resolving
 - **Character search**: Fixed an error when searching for characters (#167)
 - **Case-sensitive email login**: Normalize emails to lowercase in login, signup, password reset, and user creation flows. Includes database migration to lowercase existing emails.
 - **Emails not sending**: Fixed a bug preventing password reset, password changed, and image moderation emails from being sent.

--- a/apps/backend/src/community-colors/community-colors.resolver.ts
+++ b/apps/backend/src/community-colors/community-colors.resolver.ts
@@ -100,6 +100,7 @@ export class CommunityColorsResolver {
 
   // ==================== Field Resolvers ====================
 
+  @AllowUnauthenticated()
   @ResolveField(() => Community)
   async community(@Parent() color: CommunityColor): Promise<Community> {
     if (color.community) {

--- a/apps/backend/src/species-variants/species-variants.resolver.ts
+++ b/apps/backend/src/species-variants/species-variants.resolver.ts
@@ -97,6 +97,7 @@ export class SpeciesVariantsResolver {
     return mapPrismaSpeciesVariantConnectionToGraphQL(serviceResult);
   }
 
+  @AllowUnauthenticated()
   @AllowGlobalAdmin()
   @AllowCommunityPermission(CommunityPermission.Any)
   @ResolveCommunityFrom({ speciesId: "speciesId" })

--- a/apps/backend/src/species/species.resolver.ts
+++ b/apps/backend/src/species/species.resolver.ts
@@ -116,6 +116,7 @@ export class SpeciesResolver {
     return mapPrismaSpeciesConnectionToGraphQL(serviceResult);
   }
 
+  @AllowUnauthenticated()
   @AllowGlobalAdmin()
   @AllowCommunityPermission(CommunityPermission.Any)
   @ResolveCommunityFrom({ speciesId: "id" })

--- a/apps/backend/src/traits/traits.resolver.ts
+++ b/apps/backend/src/traits/traits.resolver.ts
@@ -82,6 +82,7 @@ export class TraitsResolver {
     return mapPrismaTraitConnectionToGraphQL(serviceResult);
   }
 
+  @AllowUnauthenticated()
   @AllowGlobalAdmin()
   @AllowCommunityPermission(CommunityPermission.Any)
   @ResolveCommunityFrom({ speciesId: "speciesId" })


### PR DESCRIPTION
## Summary
- Add `@AllowUnauthenticated()` to `speciesById`, `traitsBySpecies`, and `speciesVariantsBySpecies` queries so species pages load for logged-out users
- Add missing `@AllowUnauthenticated()` to `CommunityColor.community` field resolver

Closes #174

## Test plan
- [ ] Visit a species page while not logged in — should load species info, traits, and variants
- [ ] Visit a species page while logged in — should still work with admin actions visible