### PR TITLE
Release v9.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.3.0] - 2026-02-26
+
 ## [v9.2.1] - 2026-02-23
 
 ## [v9.2.0] - 2026-02-22

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.3.0] - 2026-02-26
+
 ### Fixed
 
 - **DeviantArt pending ownership auto-claim**: DeviantArt usernames are now resolved to UUIDs via the DA API before storing in `pending_ownership`, fixing a mismatch that prevented auto-claim from ever working for DA accounts (#208)

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v9.3.0] - 2026-02-26
+
 ### Added
 
 - **DeviantArt UUID Backfill admin UI**: Site admins can trigger and monitor the DA username-to-UUID backfill job with real-time progress bar, stats, scrollable log with character links, and cancel support

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

Release v9.3.0 — minor release with the following key changes:

### Backend
- **Fixed**: DeviantArt pending ownership auto-claim now resolves usernames to UUIDs via DA API (#208)
- **Fixed**: Character creation returns correct `ownerId` after auto-claim
- **Added**: DeviantArt UUID backfill job with GraphQL subscription progress reporting
- **Added**: GraphQL subscriptions via `graphql-ws` for real-time updates
- **Added**: DeviantArtService for username-to-UUID resolution with token caching

### Frontend
- **Added**: DeviantArt UUID Backfill admin UI with real-time progress, stats, and cancel support
- **Fixed**: Pending ownership display shows username instead of raw provider account ID

## Test plan
- [ ] Verify DeviantArt pending ownership auto-claim works for new characters
- [ ] Test DA UUID backfill job from admin UI
- [ ] Confirm GraphQL subscriptions connect and stream progress
- [ ] Verify pending ownership badges show usernames on character pages