### PR TITLE
Release v10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v10.1.0] - 2026-05-12
+
 ## [v10.0.0] - 2026-02-27
 
 ## [v9.3.0] - 2026-02-26

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v10.1.0] - 2026-05-12
+
 ### Added
 
 - **Trait clarifiers**: Traits can now opt in to free-text clarifiers (`Trait.allowsClarifier`). Character trait values carry an optional per-value `clarifier` field that round-trips through GraphQL, validation, and trait review. (#228)

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/backend",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v10.1.0] - 2026-05-12
+
 ### Added
 
 - **Trait clarifiers**: Species managers can enable per-trait clarifier text from the trait builder. When enabled, character trait values accept an optional free-text clarifier rendered parenthetically (e.g., `Common Body Mod (extra horns)`) in displays, editor chips, and trait review diffs. (#228)

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/frontend",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chardb",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "private": true,
   "packageManager": "yarn@4.10.2+sha512.0b0e54ad5381f0a35184957bd3ea44e37f5a4fb1960b903b0fb9a3c7c2c009190455c41ef2a1977b1dbd3b72c5f152da696e9c52e2bc78a011b6adea8ee73ba3",
   "workspaces": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/database",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/shared",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chardb/ui",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

Release v10.1.0 — minor version bump for the trait clarifiers feature.

### Added

- **Trait clarifiers** (#228): Traits can opt in to free-text clarifiers via `Trait.allowsClarifier`. Character trait values carry an optional per-value `clarifier` field that round-trips through GraphQL, validation, and trait review. Species managers enable this per-trait from the trait builder; clarifier text renders parenthetically (e.g., `Common Body Mod (extra horns)`) in displays, editor chips, and trait review diffs.

## Test plan

- [ ] Verify type-check passes (`yarn type-check`)
- [ ] Verify all package.json versions are 10.1.0
- [ ] Verify CHANGELOG entries are correctly dated 2026-05-12