### PR TITLE
feat(auth): ToyHouse OAuth account linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ToyHouse OAuth account linking**: Full OAuth2 integration allowing users to link their ToyHouse accounts to CharDB for identity verification and pending ownership auto-claim. Includes Passport strategy, controller, frontend callback page, Terraform secrets management, and a Prisma migration adding `TOYHOUSE` to `ExternalAccountProvider`. (#242)
+
 ## [v10.1.0] - 2026-05-12
 
 ## [v10.0.0] - 2026-02-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,5 @@
 - Use the .tmp folder in the package root for temporary files (like image uploads).
 - App-specific changes should go in the appropriate CHANGELOG.md. The root-level CHANGELOG.md is for tracking cross-cutting changes and non-app-specific changes (like CI for example)
 - PSQL credentials are in the backend .env file
-- SQS Queue Consumer: The backend runs an SQS consumer for Discord bot prize distribution. Set AWS_SQS_ENABLED=false in .env to disable it in local development. Queue URL must be configured via AWS_SQS_QUEUE_URL.
+- SQS Queue Consumer: The backend runs an SQS consumer for Discord bot prize distribution. In local development it runs via LocalStack (docker compose up localstack). Queue URL must be configured via AWS_SQS_QUEUE_URL.
 - Don't use `git -C` unless absolutely necessary. If you're already in the directory you're passing to -C, just omit it.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -70,7 +70,7 @@ S3_IMAGES_BUCKET="chardb-images"
 CLOUDFRONT_IMAGES_DOMAIN="localhost:4566/chardb-images"
 
 # SQS Queue Consumer (for Discord bot prize distribution)
-# Enable/disable the SQS consumer (set to false to disable in local dev)
+# Runs via LocalStack in local dev (docker compose up localstack)
 AWS_SQS_ENABLED="true"
 # Queue URL for prize distribution events from Discord bot
 # For LocalStack: http://localhost:4566/000000000000/chardb-prize-distribution

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -30,6 +30,14 @@ DISCORD_CALLBACK_URL="http://localhost:4000/auth/discord/callback"
 # Get this from the Bot section of your Discord application
 DISCORD_BOT_TOKEN="your-discord-bot-token"
 
+# ToyHouse OAuth (for account linking)
+# Register your app at https://toyhou.se/~developer
+# NOTE: For deployed environments, these are managed via Terraform (stored in infra/environments/{env}/terraform.tfvars)
+# The callback URL should match your backend domain + /auth/toyhouse/callback
+TOYHOUSE_CLIENT_ID="your-toyhouse-client-id"
+TOYHOUSE_CLIENT_SECRET="your-toyhouse-client-secret"
+TOYHOUSE_CALLBACK_URL="http://localhost:4000/auth/toyhouse/callback"
+
 # OpenTelemetry Tracing
 OTEL_SERVICE_NAME="chardb-backend"
 OTEL_SERVICE_VERSION="1.0.0"

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ToyHouse OAuth account linking**: Users can now link their ToyHouse accounts via OAuth2. Linked accounts trigger automatic claiming of pending character/item ownership registered to that ToyHouse username. (#242)
+
+### Fixed
+
+- **SQS enabled flag coercion**: `AWS_SQS_ENABLED=false` now correctly disables the SQS consumer. Previously, `ConfigService.get<boolean>()` returned the raw string `"false"` (truthy), so the consumer would start regardless of the flag value.
+
 ## [v10.1.0] - 2026-05-12
 
 ### Added

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -9,8 +9,10 @@ import { JwtStrategy } from "./strategies/jwt.strategy";
 import { LocalStrategy } from "./strategies/local.strategy";
 import { DeviantArtStrategy } from "./strategies/deviantart.strategy";
 import { DiscordStrategy } from "./strategies/discord.strategy";
+import { ToyhouseStrategy } from "./strategies/toyhouse.strategy";
 import { DeviantArtOAuthController } from "./deviantart-oauth.controller";
 import { DiscordOAuthController } from "./discord-oauth.controller";
+import { ToyhouseOAuthController } from "./toyhouse-oauth.controller";
 import { UsersModule } from "../users/users.module";
 import { InviteCodesModule } from "../invite-codes/invite-codes.module";
 import { DatabaseModule } from "../database/database.module";
@@ -49,7 +51,7 @@ import { AuthenticatedGuard } from "./guards/AuthenticatedGuard";
     EmailModule,
     CommunityMembersModule,
   ],
-  controllers: [DeviantArtOAuthController, DiscordOAuthController],
+  controllers: [DeviantArtOAuthController, DiscordOAuthController, ToyhouseOAuthController],
   providers: [
     AuthService,
     AuthResolver,
@@ -57,6 +59,7 @@ import { AuthenticatedGuard } from "./guards/AuthenticatedGuard";
     LocalStrategy,
     DeviantArtStrategy,
     DiscordStrategy,
+    ToyhouseStrategy,
     PermissionService,
     OwnershipService,
     CommunityResolverService,

--- a/apps/backend/src/auth/strategies/toyhouse.strategy.spec.ts
+++ b/apps/backend/src/auth/strategies/toyhouse.strategy.spec.ts
@@ -1,0 +1,124 @@
+import { ConfigService } from "@nestjs/config";
+import { ToyhouseStrategy } from "./toyhouse.strategy";
+
+// passport-oauth2 requires a concrete OAuth provider config to instantiate;
+// stub it out so we can unit-test fetchUserProfile in isolation.
+jest.mock("passport-oauth2", () => {
+  const actual = jest.requireActual("passport-oauth2");
+  return {
+    ...actual,
+    Strategy: class {
+      constructor(_opts: unknown) {}
+      authenticate() {}
+    },
+  };
+});
+
+function makeStrategy(): ToyhouseStrategy {
+  const config = {
+    get: (key: string) => {
+      const vals: Record<string, string> = {
+        TOYHOUSE_CLIENT_ID: "test-id",
+        TOYHOUSE_CLIENT_SECRET: "test-secret",
+        TOYHOUSE_CALLBACK_URL: "http://localhost:4000/auth/toyhouse/callback",
+      };
+      return vals[key];
+    },
+  } as unknown as ConfigService;
+  return new ToyhouseStrategy(config);
+}
+
+describe("ToyhouseStrategy.fetchUserProfile", () => {
+  let strategy: ToyhouseStrategy;
+  let mockFetch: jest.SpyInstance;
+
+  beforeEach(() => {
+    strategy = makeStrategy();
+    mockFetch = jest.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    mockFetch.mockRestore();
+  });
+
+  it("calls done with the profile when the API returns valid data", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 12345, username: "cooluser" }),
+    } as Response);
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    expect(done).toHaveBeenCalledWith(null, { id: "12345", username: "cooluser" });
+  });
+
+  it("calls done with an error when the API response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect((done.mock.calls[0][0] as Error).message).toBe(
+      "Failed to fetch ToyHouse user profile",
+    );
+  });
+
+  it("calls done with an error when the response is missing id", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ username: "cooluser" }), // no id
+    } as Response);
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect((done.mock.calls[0][0] as Error).message).toMatch(
+      /unexpected response shape/i,
+    );
+  });
+
+  it("calls done with an error when the response is missing username", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 99 }), // no username
+    } as Response);
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect((done.mock.calls[0][0] as Error).message).toMatch(
+      /unexpected response shape/i,
+    );
+  });
+
+  it("does not produce the string \"undefined\" as providerAccountId when id is absent", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ username: "cooluser" }), // id missing
+    } as Response);
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    // Ensure the profile was NOT called with id="undefined"
+    const profileArg = done.mock.calls[0][1];
+    expect(profileArg?.id).not.toBe("undefined");
+  });
+
+  it("calls done with an error when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network failure"));
+
+    const done = jest.fn();
+    await strategy.fetchUserProfile("token-abc", done);
+
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect((done.mock.calls[0][0] as Error).message).toBe("network failure");
+  });
+});

--- a/apps/backend/src/auth/strategies/toyhouse.strategy.ts
+++ b/apps/backend/src/auth/strategies/toyhouse.strategy.ts
@@ -8,6 +8,13 @@ export interface ToyhouseProfile {
   username: string;
 }
 
+export interface ToyhouseOAuthPayload {
+  providerAccountId: string;
+  displayName: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
 @Injectable()
 export class ToyhouseStrategy extends PassportStrategy(Strategy, "toyhouse") {
   constructor(configService: ConfigService) {
@@ -23,14 +30,6 @@ export class ToyhouseStrategy extends PassportStrategy(Strategy, "toyhouse") {
     });
 
     this.userProfile = this.fetchUserProfile.bind(this);
-  }
-
-  authenticate(req: any, options?: any) {
-    const state = req.oauthState;
-    if (state) {
-      options = { ...options, state };
-    }
-    super.authenticate(req, options);
   }
 
   async fetchUserProfile(

--- a/apps/backend/src/auth/strategies/toyhouse.strategy.ts
+++ b/apps/backend/src/auth/strategies/toyhouse.strategy.ts
@@ -50,7 +50,11 @@ export class ToyhouseStrategy extends PassportStrategy(Strategy, "toyhouse") {
 
       const data = await response.json();
 
-      done(null, { id: String(data.id), username: data.username });
+      if (!data.id || !data.username) {
+        return done(new Error("ToyHouse API returned an unexpected response shape"));
+      }
+
+      done(null, { id: String(data.id), username: String(data.username) });
     } catch (error) {
       done(error as Error);
     }

--- a/apps/backend/src/auth/strategies/toyhouse.strategy.ts
+++ b/apps/backend/src/auth/strategies/toyhouse.strategy.ts
@@ -1,0 +1,71 @@
+import { Injectable } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy } from "passport-oauth2";
+import { ConfigService } from "@nestjs/config";
+
+export interface ToyhouseProfile {
+  id: string;
+  username: string;
+}
+
+@Injectable()
+export class ToyhouseStrategy extends PassportStrategy(Strategy, "toyhouse") {
+  constructor(configService: ConfigService) {
+    super({
+      authorizationURL: "https://toyhou.se/~oauth/authorize",
+      tokenURL: "https://toyhou.se/~oauth/token",
+      clientID: configService.get("TOYHOUSE_CLIENT_ID") || "",
+      clientSecret: configService.get("TOYHOUSE_CLIENT_SECRET") || "",
+      callbackURL:
+        configService.get("TOYHOUSE_CALLBACK_URL") ||
+        "http://localhost:4000/auth/toyhouse/callback",
+      passReqToCallback: false,
+    });
+
+    this.userProfile = this.fetchUserProfile.bind(this);
+  }
+
+  authenticate(req: any, options?: any) {
+    const state = req.oauthState;
+    if (state) {
+      options = { ...options, state };
+    }
+    super.authenticate(req, options);
+  }
+
+  async fetchUserProfile(
+    accessToken: string,
+    done: (err?: Error | null, profile?: ToyhouseProfile) => void,
+  ) {
+    try {
+      const response = await fetch("https://toyhou.se/~api/v1/me", {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (!response.ok) {
+        return done(new Error("Failed to fetch ToyHouse user profile"));
+      }
+
+      const data = await response.json();
+
+      done(null, { id: String(data.id), username: data.username });
+    } catch (error) {
+      done(error as Error);
+    }
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: ToyhouseProfile,
+  ) {
+    return {
+      providerAccountId: profile.id,
+      displayName: profile.username,
+      accessToken,
+      refreshToken,
+    };
+  }
+}

--- a/apps/backend/src/auth/toyhouse-oauth.controller.ts
+++ b/apps/backend/src/auth/toyhouse-oauth.controller.ts
@@ -9,6 +9,7 @@ import { ExternalAccountsService } from "../external-accounts/external-accounts.
 import { ExternalAccountProvider } from "@prisma/client";
 import { CurrentUser } from "./decorators/CurrentUser";
 import { User } from "@prisma/client";
+import { ToyhouseOAuthPayload } from "./strategies/toyhouse.strategy";
 
 @Controller("auth/toyhouse")
 export class ToyhouseOAuthController {
@@ -65,7 +66,7 @@ export class ToyhouseOAuthController {
         throw new Error("Invalid or expired state token");
       }
 
-      const oauthData = req.user as any;
+      const oauthData = req.user as ToyhouseOAuthPayload;
       if (!oauthData?.providerAccountId || !oauthData?.displayName) {
         throw new Error("Invalid OAuth response");
       }

--- a/apps/backend/src/auth/toyhouse-oauth.controller.ts
+++ b/apps/backend/src/auth/toyhouse-oauth.controller.ts
@@ -26,7 +26,7 @@ export class ToyhouseOAuthController {
       { sub: user.id },
       { secret: jwtSecret + "_O", expiresIn: "10m" },
     );
-    const clientId = this.configService.get("TOYHOUSE_CLIENT_ID");
+    const clientId = this.configService.getOrThrow("TOYHOUSE_CLIENT_ID");
     const callbackUrl =
       this.configService.get("TOYHOUSE_CALLBACK_URL") ||
       "http://localhost:4000/auth/toyhouse/callback";

--- a/apps/backend/src/auth/toyhouse-oauth.controller.ts
+++ b/apps/backend/src/auth/toyhouse-oauth.controller.ts
@@ -1,0 +1,100 @@
+import { Controller, Get, Req, Res, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { Request, Response } from "express";
+import { AllowUnauthenticated } from "./decorators/AllowUnauthenticated";
+import { AllowAnyAuthenticated } from "./decorators/AllowAnyAuthenticated";
+import { ConfigService } from "@nestjs/config";
+import { JwtService } from "@nestjs/jwt";
+import { ExternalAccountsService } from "../external-accounts/external-accounts.service";
+import { ExternalAccountProvider } from "@prisma/client";
+import { CurrentUser } from "./decorators/CurrentUser";
+import { User } from "@prisma/client";
+
+@Controller("auth/toyhouse")
+export class ToyhouseOAuthController {
+  constructor(
+    private configService: ConfigService,
+    private jwtService: JwtService,
+    private externalAccountsService: ExternalAccountsService,
+  ) {}
+
+  @Get()
+  @AllowAnyAuthenticated()
+  async initiateOAuth(@CurrentUser() user: User) {
+    const jwtSecret = this.configService.get("JWT_SECRET");
+    const state = this.jwtService.sign(
+      { sub: user.id },
+      { secret: jwtSecret + "_O", expiresIn: "10m" },
+    );
+    const clientId = this.configService.get("TOYHOUSE_CLIENT_ID");
+    const callbackUrl =
+      this.configService.get("TOYHOUSE_CALLBACK_URL") ||
+      "http://localhost:4000/auth/toyhouse/callback";
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: callbackUrl,
+      response_type: "code",
+      state,
+    });
+
+    return { url: `https://toyhou.se/~oauth/authorize?${params.toString()}` };
+  }
+
+  @Get("callback")
+  @AllowUnauthenticated()
+  @UseGuards(AuthGuard("toyhouse"))
+  async handleCallback(@Req() req: Request, @Res() res: Response) {
+    const frontendUrl =
+      this.configService.get("FRONTEND_URL") || "http://localhost:3000";
+
+    try {
+      const state = req.query.state as string;
+      if (!state) {
+        throw new Error("Missing state parameter");
+      }
+
+      let userId: string;
+      try {
+        const jwtSecret = this.configService.get("JWT_SECRET");
+        const statePayload = this.jwtService.verify(state, {
+          secret: jwtSecret + "_O",
+        });
+        userId = statePayload.sub;
+      } catch {
+        throw new Error("Invalid or expired state token");
+      }
+
+      const oauthData = req.user as any;
+      if (!oauthData?.providerAccountId || !oauthData?.displayName) {
+        throw new Error("Invalid OAuth response");
+      }
+
+      const result = await this.externalAccountsService.linkExternalAccount(
+        userId,
+        ExternalAccountProvider.TOYHOUSE,
+        oauthData.providerAccountId,
+        oauthData.displayName,
+      );
+
+      const callbackUrl = new URL(`${frontendUrl}/auth/toyhouse/callback`);
+      callbackUrl.searchParams.set("success", "true");
+      if (result.claimedCharacterIds.length > 0) {
+        callbackUrl.searchParams.set(
+          "claimedCharacters",
+          result.claimedCharacterIds.length.toString(),
+        );
+      }
+      if (result.claimedItemIds.length > 0) {
+        callbackUrl.searchParams.set(
+          "claimedItems",
+          result.claimedItemIds.length.toString(),
+        );
+      }
+      res.redirect(callbackUrl.toString());
+    } catch (error) {
+      const errorUrl = `${frontendUrl}/auth/toyhouse/callback?error=${encodeURIComponent(error.message)}`;
+      res.redirect(errorUrl);
+    }
+  }
+}

--- a/apps/backend/src/queue-consumer/README.md
+++ b/apps/backend/src/queue-consumer/README.md
@@ -118,8 +118,8 @@ Messages are automatically retried up to 3 times (based on `maxReceiveCount` in 
 AWS_SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account/queue-name
 AWS_REGION=us-east-1
 
-# Optional
-AWS_SQS_ENABLED=true  # Set to false to disable consumer
+# Optional (defaults to true; runs via LocalStack in local dev)
+AWS_SQS_ENABLED=true
 ```
 
 ### Queue Parameters
@@ -179,26 +179,15 @@ Logs include:
 
 ### Local Testing
 
-1. **Disable consumer in local dev:**
+Local development uses LocalStack (via `docker compose up localstack`) for SQS.
+The `.env` default points to `http://localhost:4566` with `AWS_SQS_ENABLED=true`.
+
+1. **Start LocalStack:**
    ```bash
-   AWS_SQS_ENABLED=false
+   docker compose up localstack
    ```
 
-2. **Use LocalStack for local SQS:**
-   ```bash
-   # In docker-compose.yml
-   localstack:
-     image: localstack/localstack
-     ports:
-       - "4566:4566"
-     environment:
-       - SERVICES=sqs
-
-   # In .env
-   AWS_SQS_QUEUE_URL=http://localhost:4566/000000000000/test-queue
-   ```
-
-3. **Create local queue:**
+2. **Create local queue:**
    ```bash
    aws --endpoint-url=http://localhost:4566 sqs create-queue \
      --queue-name test-prize-distribution

--- a/apps/backend/src/queue-consumer/queue-consumer.module.spec.ts
+++ b/apps/backend/src/queue-consumer/queue-consumer.module.spec.ts
@@ -1,0 +1,48 @@
+import { ConfigService } from "@nestjs/config";
+import { sqsModuleFactory } from "./queue-consumer.module";
+
+function makeConfig(vars: Record<string, string>): ConfigService {
+  return {
+    get: (key: string, defaultValue?: string) => vars[key] ?? defaultValue,
+  } as unknown as ConfigService;
+}
+
+describe("sqsModuleFactory", () => {
+  const baseVars = {
+    AWS_SQS_QUEUE_URL: "http://localhost:4566/000000000000/chardb-prize-distribution",
+    AWS_REGION: "us-east-1",
+  };
+
+  it('enables consumer when AWS_SQS_ENABLED is "true"', () => {
+    const config = makeConfig({ ...baseVars, AWS_SQS_ENABLED: "true" });
+    const result = sqsModuleFactory(config);
+    expect(result.consumers).toHaveLength(1);
+  });
+
+  it("enables consumer when AWS_SQS_ENABLED is absent (default true)", () => {
+    const config = makeConfig({ ...baseVars });
+    const result = sqsModuleFactory(config);
+    expect(result.consumers).toHaveLength(1);
+  });
+
+  it('disables consumer when AWS_SQS_ENABLED is the string "false"', () => {
+    // Regression: ConfigService.get<boolean>() returns the raw string "false",
+    // which is truthy — must compare as string, not coerce via generic.
+    const config = makeConfig({ ...baseVars, AWS_SQS_ENABLED: "false" });
+    const result = sqsModuleFactory(config);
+    expect(result.consumers).toHaveLength(0);
+  });
+
+  it("disables consumer when AWS_SQS_QUEUE_URL is absent", () => {
+    const config = makeConfig({ AWS_SQS_ENABLED: "true" });
+    const result = sqsModuleFactory(config);
+    expect(result.consumers).toHaveLength(0);
+  });
+
+  it("passes queue URL and region through to consumer config", () => {
+    const config = makeConfig({ ...baseVars, AWS_SQS_ENABLED: "true" });
+    const result = sqsModuleFactory(config);
+    expect(result.consumers[0].queueUrl).toBe(baseVars.AWS_SQS_QUEUE_URL);
+    expect(result.consumers[0].region).toBe("us-east-1");
+  });
+});

--- a/apps/backend/src/queue-consumer/queue-consumer.module.ts
+++ b/apps/backend/src/queue-consumer/queue-consumer.module.ts
@@ -8,6 +8,29 @@ import { DatabaseModule } from "../database/database.module";
 import { ItemsModule } from "../items/items.module";
 import { PendingOwnershipModule } from "../pending-ownership/pending-ownership.module";
 
+export function sqsModuleFactory(configService: ConfigService) {
+  const enabled = configService.get("AWS_SQS_ENABLED", "true") !== "false";
+  const queueUrl = configService.get<string>("AWS_SQS_QUEUE_URL", "");
+  const region = configService.get<string>("AWS_REGION", "us-east-1");
+
+  if (!enabled || !queueUrl) {
+    return { consumers: [], producers: [] };
+  }
+
+  return {
+    consumers: [
+      {
+        name: "prize-distribution",
+        queueUrl: queueUrl,
+        region: region,
+        batchSize: 5,
+        waitTimeSeconds: 5,
+      },
+    ],
+    producers: [],
+  };
+}
+
 @Module({
   imports: [
     ConfigModule,
@@ -17,32 +40,7 @@ import { PendingOwnershipModule } from "../pending-ownership/pending-ownership.m
     SqsModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const enabled = configService.get<boolean>("AWS_SQS_ENABLED", true);
-        const queueUrl = configService.get<string>("AWS_SQS_QUEUE_URL", "");
-        const region = configService.get<string>("AWS_REGION", "us-east-1");
-
-        // If disabled or no queue URL, return empty configuration
-        if (!enabled || !queueUrl) {
-          return {
-            consumers: [],
-            producers: [],
-          };
-        }
-
-        return {
-          consumers: [
-            {
-              name: "prize-distribution",
-              queueUrl: queueUrl,
-              region: region,
-              batchSize: 5,
-              waitTimeSeconds: 5,
-            },
-          ],
-          producers: [],
-        };
-      },
+      useFactory: sqsModuleFactory,
     }),
   ],
   providers: [PrizeQueueHandler, ItemPrizeHandler, CharacterPrizeHandler],

--- a/apps/backend/src/schema.gql
+++ b/apps/backend/src/schema.gql
@@ -868,6 +868,7 @@ type ExternalAccount {
 enum ExternalAccountProvider {
   DEVIANTART
   DISCORD
+  TOYHOUSE
 }
 
 type FollowListResult {
@@ -1337,6 +1338,7 @@ enum ModerationRejectionReason {
 """The moderation status of an image"""
 enum ModerationStatus {
   APPROVED
+  CANCELLED
   PENDING
   REJECTED
 }

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ToyHouse account linking UI**: "Link ToyHouse Account" button on the Edit Profile page initiates the OAuth2 flow. Linked accounts are shown in the Connected Accounts section with a "TH" badge. On successful callback, shows a success toast and (if pending items were claimed) a summary of claimed characters/items. (#242)
+
 ## [v10.1.0] - 2026-05-12
 
 ### Added

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -61,6 +61,7 @@ import { EditSpeciesPage } from "./pages/EditSpeciesPage";
 import { DeviantArtBackfillPage } from "./pages/DeviantArtBackfillPage";
 import { DeviantArtCallbackPage } from "./pages/DeviantArtCallbackPage";
 import { DiscordCallbackPage } from "./pages/DiscordCallbackPage";
+import { ToyhouseCallbackPage } from "./pages/ToyhouseCallbackPage";
 import { CommunityItemsAdminPage } from "./pages/CommunityItemsAdminPage";
 import { CommunityInventoryPage } from "./pages/CommunityInventoryPage";
 import { CommunityColorPalettePage } from "./pages/CommunityColorPalettePage";
@@ -114,6 +115,10 @@ function App() {
         <Route
           path="/auth/discord/callback"
           element={<DiscordCallbackPage />}
+        />
+        <Route
+          path="/auth/toyhouse/callback"
+          element={<ToyhouseCallbackPage />}
         />
 
         {/* Protected routes */}

--- a/apps/frontend/src/pages/EditProfilePage.tsx
+++ b/apps/frontend/src/pages/EditProfilePage.tsx
@@ -425,6 +425,40 @@ export const EditProfilePage: React.FC = () => {
     }
   };
 
+  const handleLinkToyhouse = async () => {
+    const token = localStorage.getItem("accessToken");
+
+    if (!token) {
+      toast.error("Please log in to link your ToyHouse account");
+      return;
+    }
+
+    try {
+      const backendUrl =
+        import.meta.env.VITE_API_URL || "http://localhost:4000";
+      const response = await fetch(`${backendUrl}/auth/toyhouse`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to initiate OAuth flow");
+      }
+
+      const data = await response.json();
+
+      if (!data.url) {
+        throw new Error("No OAuth URL returned");
+      }
+
+      window.location.href = data.url;
+    } catch (error: any) {
+      console.error("Error initiating OAuth:", error);
+      toast.error(error.message || "Failed to start ToyHouse linking");
+    }
+  };
+
   const handleUnlink = async (provider: ExternalAccountProvider) => {
     if (!confirm(`Are you sure you want to unlink your ${provider} account?`)) {
       return;
@@ -544,8 +578,8 @@ export const EditProfilePage: React.FC = () => {
       <Section>
         <SectionTitle>Connected Accounts</SectionTitle>
         <SectionDescription>
-          Link your external accounts (DeviantArt, Discord) to verify ownership
-          and connect with the community
+          Link your external accounts (DeviantArt, Discord, ToyHouse) to verify
+          ownership and connect with the community
         </SectionDescription>
 
         {loadingAccounts ? (
@@ -563,7 +597,9 @@ export const EditProfilePage: React.FC = () => {
                       ? "DA"
                       : account.provider === "DISCORD"
                         ? "DC"
-                        : account.provider.charAt(0)}
+                        : account.provider === "TOYHOUSE"
+                          ? "TH"
+                          : account.provider.charAt(0)}
                   </AccountIcon>
                   <AccountDetails>
                     <AccountName>{account.displayName}</AccountName>
@@ -610,6 +646,13 @@ export const EditProfilePage: React.FC = () => {
           ) && (
             <SmallButton variant="primary" onClick={handleLinkDiscord}>
               Link Discord Account
+            </SmallButton>
+          )}
+          {!externalAccountsData?.myExternalAccounts?.some(
+            (acc: any) => acc.provider === "TOYHOUSE",
+          ) && (
+            <SmallButton variant="primary" onClick={handleLinkToyhouse}>
+              Link ToyHouse Account
             </SmallButton>
           )}
         </div>

--- a/apps/frontend/src/pages/EditProfilePage.tsx
+++ b/apps/frontend/src/pages/EditProfilePage.tsx
@@ -382,9 +382,9 @@ export const EditProfilePage: React.FC = () => {
 
       // Redirect to the OAuth URL (no tokens in URL)
       window.location.href = data.url;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error initiating OAuth:", error);
-      toast.error(error.message || "Failed to start DeviantArt linking");
+      toast.error(error instanceof Error ? error.message : "Failed to start DeviantArt linking");
     }
   };
 
@@ -419,9 +419,9 @@ export const EditProfilePage: React.FC = () => {
 
       // Redirect to the OAuth URL (no tokens in URL)
       window.location.href = data.url;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error initiating OAuth:", error);
-      toast.error(error.message || "Failed to start Discord linking");
+      toast.error(error instanceof Error ? error.message : "Failed to start Discord linking");
     }
   };
 
@@ -453,9 +453,9 @@ export const EditProfilePage: React.FC = () => {
       }
 
       window.location.href = data.url;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error initiating OAuth:", error);
-      toast.error(error.message || "Failed to start ToyHouse linking");
+      toast.error(error instanceof Error ? error.message : "Failed to start ToyHouse linking");
     }
   };
 
@@ -472,9 +472,9 @@ export const EditProfilePage: React.FC = () => {
       });
       toast.success(`${provider} account unlinked successfully`);
       refetchAccounts();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error unlinking account:", error);
-      toast.error(error.message || `Failed to unlink ${provider} account`);
+      toast.error(error instanceof Error ? error.message : `Failed to unlink ${provider} account`);
     }
   };
 

--- a/apps/frontend/src/pages/ToyhouseCallbackPage.tsx
+++ b/apps/frontend/src/pages/ToyhouseCallbackPage.tsx
@@ -73,7 +73,7 @@ export function ToyhouseCallbackPage() {
   const hasProcessed = useRef(false);
 
   useEffect(() => {
-    const processCallback = async () => {
+    const processCallback = () => {
       if (hasProcessed.current) {
         return;
       }

--- a/apps/frontend/src/pages/ToyhouseCallbackPage.tsx
+++ b/apps/frontend/src/pages/ToyhouseCallbackPage.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import styled from 'styled-components';
+import toast from 'react-hot-toast';
+import { Alert } from '@chardb/ui';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem;
+`;
+
+const Message = styled.div`
+  font-size: 1.125rem;
+  color: ${props => props.theme.colors.text.secondary};
+  text-align: center;
+`;
+
+const SuccessContainer = styled.div`
+  max-width: 600px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const Title = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: ${props => props.theme.colors.text.primary};
+  text-align: center;
+  margin: 0;
+`;
+
+const ViewLink = styled(Link)`
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: ${props => props.theme.colors.primary};
+  text-decoration: none;
+  font-weight: 500;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const Spinner = styled.div`
+  border: 3px solid ${props => props.theme.colors.border};
+  border-top-color: ${props => props.theme.colors.primary};
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+export function ToyhouseCallbackPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [isProcessing, setIsProcessing] = useState(true);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [claimedCharacters, setClaimedCharacters] = useState(0);
+  const [claimedItems, setClaimedItems] = useState(0);
+  const hasProcessed = useRef(false);
+
+  useEffect(() => {
+    const processCallback = async () => {
+      if (hasProcessed.current) {
+        return;
+      }
+      hasProcessed.current = true;
+
+      const error = searchParams.get('error');
+      const success = searchParams.get('success');
+      const claimedChars = searchParams.get('claimedCharacters');
+      const claimedItms = searchParams.get('claimedItems');
+
+      setIsProcessing(false);
+
+      if (error) {
+        toast.error(`Failed to link ToyHouse account: ${error}`);
+        setTimeout(() => navigate('/profile/edit'), 2000);
+      } else if (success) {
+        const charsCount = parseInt(claimedChars || '0', 10);
+        const itemsCount = parseInt(claimedItms || '0', 10);
+
+        setClaimedCharacters(charsCount);
+        setClaimedItems(itemsCount);
+
+        if (charsCount > 0 || itemsCount > 0) {
+          setShowSuccess(true);
+          toast.success('Successfully linked ToyHouse account and claimed pending items!');
+          setTimeout(() => navigate('/profile'), 5000);
+        } else {
+          toast.success('Successfully linked ToyHouse account!');
+          setTimeout(() => navigate('/profile/edit'), 2000);
+        }
+      } else {
+        toast.error('Invalid callback response');
+        setTimeout(() => navigate('/profile/edit'), 2000);
+      }
+    };
+
+    processCallback();
+  }, [searchParams, navigate]);
+
+  if (isProcessing) {
+    return (
+      <Container>
+        <Spinner />
+        <Message>Completing account linking...</Message>
+      </Container>
+    );
+  }
+
+  if (showSuccess) {
+    return (
+      <Container>
+        <SuccessContainer>
+          <Title>ToyHouse Account Linked Successfully!</Title>
+
+          <Alert variant="success">
+            <div>
+              <strong>Congratulations!</strong> You've claimed:
+              <ul style={{ marginTop: '0.5rem', marginBottom: '0.5rem', paddingLeft: '1.5rem' }}>
+                {claimedCharacters > 0 && (
+                  <li>{claimedCharacters} character{claimedCharacters > 1 ? 's' : ''}</li>
+                )}
+                {claimedItems > 0 && (
+                  <li>{claimedItems} item{claimedItems > 1 ? 's' : ''}</li>
+                )}
+              </ul>
+              <ViewLink to="/profile">View Your Profile →</ViewLink>
+            </div>
+          </Alert>
+
+          <Message>Redirecting to your profile...</Message>
+        </SuccessContainer>
+      </Container>
+    );
+  }
+
+  return null;
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -92,6 +92,19 @@ resource "aws_secretsmanager_secret_version" "deviantart_client_secret" {
   secret_string = var.deviantart_client_secret
 }
 
+# ToyHouse client secret
+resource "aws_secretsmanager_secret" "toyhouse_client_secret" {
+  name        = "${var.project_name}-${var.environment}-toyhouse-secret"
+  description = "ToyHouse OAuth client secret"
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "toyhouse_client_secret" {
+  secret_id     = aws_secretsmanager_secret.toyhouse_client_secret.id
+  secret_string = var.toyhouse_client_secret
+}
+
 # Discord client secret
 resource "aws_secretsmanager_secret" "discord_client_secret" {
   name        = "${var.project_name}-${var.environment}-discord-secret"
@@ -522,6 +535,14 @@ module "ecs" {
       value = var.deviantart_callback_url
     },
     {
+      name  = "TOYHOUSE_CLIENT_ID"
+      value = var.toyhouse_client_id
+    },
+    {
+      name  = "TOYHOUSE_CALLBACK_URL"
+      value = var.toyhouse_callback_url
+    },
+    {
       name  = "DISCORD_CLIENT_ID"
       value = var.discord_client_id
     },
@@ -634,6 +655,10 @@ module "ecs" {
       valueFrom = aws_secretsmanager_secret.deviantart_client_secret.arn
     },
     {
+      name      = "TOYHOUSE_CLIENT_SECRET"
+      valueFrom = aws_secretsmanager_secret.toyhouse_client_secret.arn
+    },
+    {
       name      = "DISCORD_CLIENT_SECRET"
       valueFrom = aws_secretsmanager_secret.discord_client_secret.arn
     },
@@ -652,6 +677,7 @@ module "ecs" {
     aws_secretsmanager_secret.database_url.arn,
     aws_secretsmanager_secret.jwt_secret.arn,
     aws_secretsmanager_secret.deviantart_client_secret.arn,
+    aws_secretsmanager_secret.toyhouse_client_secret.arn,
     aws_secretsmanager_secret.discord_client_secret.arn,
     aws_secretsmanager_secret.discord_bot_token.arn,
     aws_secretsmanager_secret.otel_otlp_headers.arn,

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -247,6 +247,23 @@ variable "discord_callback_url" {
   type        = string
 }
 
+variable "toyhouse_client_id" {
+  description = "ToyHouse OAuth client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "toyhouse_client_secret" {
+  description = "ToyHouse OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "toyhouse_callback_url" {
+  description = "ToyHouse OAuth callback URL"
+  type        = string
+}
+
 variable "discord_bot_token" {
   description = "Discord bot token for bot integration"
   type        = string

--- a/packages/database/prisma/migrations/20260619021600_add_toyhouse_provider/migration.sql
+++ b/packages/database/prisma/migrations/20260619021600_add_toyhouse_provider/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ExternalAccountProvider" ADD VALUE 'TOYHOUSE';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -37,6 +37,7 @@ enum TraitValueType {
 enum ExternalAccountProvider {
   DEVIANTART
   DISCORD
+  TOYHOUSE
 }
 
 enum ModerationStatus {


### PR DESCRIPTION
## Summary

- Adds ToyHouse as a verified OAuth account linking provider (same pattern as Discord/DeviantArt)
- Discovered toyhou.se does have an OAuth2 API (`~oauth/authorize`, `~oauth/token`, `~api/v1/me`) — used by Lorekeeper and other community tools; issue #242 had incorrect info
- Users authenticate directly with ToyHouse, giving us a verified `id` + `username` rather than an honor-system self-report

## Changes

- **Migration**: adds `TOYHOUSE` to the `ExternalAccountProvider` Prisma/Postgres enum
- **Backend strategy** (`toyhouse.strategy.ts`): `passport-oauth2` against toyhou.se endpoints, maps `id` + `username` from `~api/v1/me`
- **Backend controller** (`toyhouse-oauth.controller.ts`): `GET /auth/toyhouse` returns authorize URL; `GET /auth/toyhouse/callback` verifies state JWT, links account, fires `PendingOwnership` claim auto-transfer
- **Auth module**: registers new strategy and controller
- **Frontend**: `ToyhouseCallbackPage`, route at `/auth/toyhouse/callback`, link/unlink button in profile edit page, `TH` icon abbreviation in linked accounts list
- **`.env.example`**: documents `TOYHOUSE_CLIENT_ID`, `TOYHOUSE_CLIENT_SECRET`, `TOYHOUSE_CALLBACK_URL`

## Setup required

Register an app at https://toyhou.se/~developer and set callback URL to `<backend-url>/auth/toyhouse/callback`. Add the three env vars to the deployment.

## Test plan

- [ ] Link a ToyHouse account via profile edit → redirects to TH OAuth → returns to `/auth/toyhouse/callback` with success toast
- [ ] Linked TH account appears in Connected Accounts list with `TH` icon
- [ ] Unlink button removes the account
- [ ] Attempting to link a TH account already linked to another user shows conflict error
- [ ] If a character has a pending TH ownership claim matching the linked account, it is auto-claimed on link
- [ ] Missing/invalid state token redirects to profile edit with error toast

Closes #242